### PR TITLE
chore(home-assistant): Update commands volume permission

### DIFF
--- a/services/smart_home/compose.yaml
+++ b/services/smart_home/compose.yaml
@@ -8,7 +8,7 @@ services:
     network_mode: host
     volumes:
       - ${HOME_ASSISTANT_VOLUME}:/config
-      - ./config/home-assistant/commands:/commands
+      - ./config/home-assistant/commands:/commands:ro
     #  - ./config/otel-collector/run:/etc/services.d/home-assistant/run
     logging:
       driver: json-file


### PR DESCRIPTION
This updates the commands volume permission to read-only for better security. The `:ro` flag is set, mounting it as read-only within the container, which can enhance security by preventing accidental modifications from within the container.