### PR TITLE
feature(lgtm): Setup LGTM with OpenTelemetry backend

### DIFF
--- a/services/monitoring/compose.yaml
+++ b/services/monitoring/compose.yaml
@@ -1,50 +1,8 @@
 services:
-  loki:
-    image: grafana/loki:latest
-    ports:
-      - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
-    networks:
-      - loki
-
-  promtail:
-    image: grafana/promtail:latest
-    volumes:
-      - /var/log:/var/log
-    command: -config.file=/etc/promtail/config.yml
-    networks:
-      - loki
-
-  grafana:
-    environment:
-      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_FEATURE_TOGGLES_ENABLE=alertingSimplifiedRouting,alertingQueryAndExpressionsStepMode
-    entrypoint:
-      - sh
-      - -euc
-      - |
-        mkdir -p /etc/grafana/provisioning/datasources
-        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
-        apiVersion: 1
-        datasources:
-        - name: Loki
-          type: loki
-          access: proxy 
-          orgId: 1
-          url: http://loki:3100
-          basicAuth: false
-          isDefault: true
-          version: 1
-          editable: false
-        EOF
-        /run.sh
-    image: grafana/grafana:latest
-    ports:
-      - "3000:3000"
-    networks:
-      - loki
-
-networks:
   lgtm:
+    container_name: lgtm
+    image: grafana/otel-lgtm
+    restart: unless-stopped
+    ports:
+      - 4317:4317
+      - 4318:4318

--- a/services/monitoring/compose.yaml
+++ b/services/monitoring/compose.yaml
@@ -6,3 +6,8 @@ services:
     ports:
       - 4317:4317
       - 4318:4318
+    logging:
+    driver: json-file
+    options:
+      max-size: "10mb"
+      max-file: "1"


### PR DESCRIPTION
This replaces the initial monitoring stack with a preconfigured image, `grafana/otel-lgtm`.